### PR TITLE
Improve comment readability by using --main-text color instead of --dimmer-text

### DIFF
--- a/src/YouTubeCatppuccinFrappe.user.css
+++ b/src/YouTubeCatppuccinFrappe.user.css
@@ -2126,7 +2126,7 @@
         background-color: var(--second-background) !important;
     }
     /*comments themselves*/
-    #author-text.yt-simple-endpoint.ytd-comment-renderer {
+    #author-text.yt-simple-endpoint.ytd-comment-renderer, #content.style-scope #content-text {
         color: var(--main-text) !important;
     }
     #author-text.yt-simple-endpoint.ytd-comment-renderer:hover {

--- a/src/YouTubeCatppuccinLatte.user.css
+++ b/src/YouTubeCatppuccinLatte.user.css
@@ -2126,7 +2126,7 @@
         background-color: var(--second-background) !important;
     }
     /*comments themselves*/
-    #author-text.yt-simple-endpoint.ytd-comment-renderer {
+    #author-text.yt-simple-endpoint.ytd-comment-renderer, #content.style-scope #content-text {
         color: var(--main-text) !important;
     }
     #author-text.yt-simple-endpoint.ytd-comment-renderer:hover {

--- a/src/YouTubeCatppuccinMacchiato.user.css
+++ b/src/YouTubeCatppuccinMacchiato.user.css
@@ -2127,7 +2127,7 @@
         background-color: var(--second-background) !important;
     }
     /*comments themselves*/
-    #author-text.yt-simple-endpoint.ytd-comment-renderer {
+    #author-text.yt-simple-endpoint.ytd-comment-renderer, #content.style-scope #content-text {
         color: var(--main-text) !important;
     }
     #author-text.yt-simple-endpoint.ytd-comment-renderer:hover {

--- a/src/YouTubeCatppuccinMocha.user.css
+++ b/src/YouTubeCatppuccinMocha.user.css
@@ -2127,7 +2127,7 @@
         background-color: var(--second-background) !important;
     }
     /*comments themselves*/
-    #author-text.yt-simple-endpoint.ytd-comment-renderer {
+    #author-text.yt-simple-endpoint.ytd-comment-renderer, #content.style-scope #content-text {
         color: var(--main-text) !important;
     }
     #author-text.yt-simple-endpoint.ytd-comment-renderer:hover {


### PR DESCRIPTION
The images below this are what comments look like right now. They seem to be using the --dimmer-text color, making them somewhat difficult to read.
<img width="470" alt="image" src="https://user-images.githubusercontent.com/73204320/211252501-e40032be-10b0-4f33-ba9c-de5c414539e3.png">
<img width="482" alt="image" src="https://user-images.githubusercontent.com/73204320/211252601-5f3ca923-dbe4-4a6d-ac47-ba7896ceb2f9.png">
<img width="474" alt="image" src="https://user-images.githubusercontent.com/73204320/211252884-4901dfac-5ee9-4e71-b0e9-604b4dbf59b0.png">
<img width="476" alt="image" src="https://user-images.githubusercontent.com/73204320/211252999-5a07ff4b-8d25-406d-9108-a205b0fab6ab.png">


The images below this are what they look like after making `#content.style-scope #content-text` use the `--main-text` color.
<img width="465" alt="image" src="https://user-images.githubusercontent.com/73204320/211253331-ec39aba7-0628-4f70-a384-22f2c2e79914.png">
<img width="471" alt="image" src="https://user-images.githubusercontent.com/73204320/211253551-7d8750c9-8ae2-404d-9f84-117a55c7eb0f.png">
<img width="460" alt="image" src="https://user-images.githubusercontent.com/73204320/211253792-94b202d8-34cf-40da-b12b-1b9abf7c8508.png">
<img width="468" alt="image" src="https://user-images.githubusercontent.com/73204320/211253940-70313c2f-ee4c-479e-bb52-1c830b4876af.png">
