### PR TITLE
Fix reply text colour being set to background color

### DIFF
--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -1145,7 +1145,7 @@
     .yt-spec-button-shape-next[aria-label="Comment"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string,
     .yt-spec-button-shape-next[aria-label="Buy and Send"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string,
     .yt-spec-button-shape-next[aria-label="Got it"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string {
-        color: var(--text) !important;
+        color: var(--main-text) !important;
     }
 
     #comment-chip-price {

--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -1145,7 +1145,7 @@
     .yt-spec-button-shape-next[aria-label="Comment"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string,
     .yt-spec-button-shape-next[aria-label="Buy and Send"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string,
     .yt-spec-button-shape-next[aria-label="Got it"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string {
-        color: var(--main-background) !important;
+        color: var(--text) !important;
     }
 
     #comment-chip-price {

--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/youtube
 @homepageURL https://github.com/catppuccin/youtube
-@version 2.1.2
+@version 2.1.3
 @updateURL https://github.com/catppuccin/youtube/raw/main/src/catppuccin.user.css
 @description Soothing pastel theme for YouTube
 @author isabelroses
@@ -1141,11 +1141,14 @@
         background-color: var(--main-background) !important;
     }
 
-    .yt-spec-button-shape-next[aria-label="Reply"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string,
+    .yt-spec-button-shape-next[aria-label="Reply"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string {
+      color: var(--main-text) !important;
+    }
+    
     .yt-spec-button-shape-next[aria-label="Comment"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string,
     .yt-spec-button-shape-next[aria-label="Buy and Send"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string,
     .yt-spec-button-shape-next[aria-label="Got it"] .yt-spec-button-shape-next--button-text-content .yt-core-attributed-string {
-        color: var(--main-text) !important;
+        color: var(--main-background) !important;
     }
 
     #comment-chip-price {


### PR DESCRIPTION
On my setup (Firefox, Macchiato Peach), the reply colour text appears as the background text.

This can be fixed by changing line 1148 from `color: var(--main-background) !important;` to `color: var(--main-text) !important;`.

 `text` can also be used instead of `main-text`, but I thought that main-text was a closer match to the default Youtube theme.

### Youtube default:
![image](https://user-images.githubusercontent.com/68666531/232145666-fea3cef6-b85f-45d4-92a7-8d7cc9e9a89b.png)

### Current theme version:
![image](https://user-images.githubusercontent.com/68666531/232145863-6abf7be8-9519-494f-8c5d-3138e7487691.png)

### With fix:
![image](https://user-images.githubusercontent.com/68666531/232146252-702ef347-adf7-4a00-bef3-f4b334f15082.png)
