### PR TITLE
Fix: Original background color when playing on dark mode

### DIFF
--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -1193,6 +1193,10 @@
             background-color: @surface0 !important;
         }
 
+        #cinematics > div > canvas{
+            visibility: hidden;
+        }
+
         #name:hover {
             color: @accent-colour !important;
         }


### PR DESCRIPTION
I hid the canvas from the 'cinematics' div and so far haven't experienced any issues. This is definitively fixing the problem (#14) (#15) when used in dark mode.