### PR TITLE
fix: default background in pressed feedback button

### DIFF
--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -2684,9 +2684,6 @@
         .yt-spec-button-shape-next--overlay,
         .yt-spec-button-shape-next--call-to-action,
         .yt-spec-button-shape-next--mono {
-            &[aria-pressed="true"] {
-                background-color: @surface0 !important;
-            }
             &:hover {
                 background-color: @surface1 !important;
                 .yt-spec-touch-feedback-shape__fill,


### PR DESCRIPTION
Vanilla:
![image](https://github.com/catppuccin/youtube/assets/61998307/34eef3f8-f894-4407-8c67-e7698ce81c41)

Before this patch (highlights background when feedback button is pressed):
![image](https://github.com/catppuccin/youtube/assets/61998307/476c4138-0143-4a84-88d0-874a0496d1fe)

This patch:
![image](https://github.com/catppuccin/youtube/assets/61998307/f2fd1fd7-9f58-4a11-8eb7-46c4234c77d2)
