### PR TITLE
Fix spacing in creator comment badges

### DIFF
--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -2,7 +2,7 @@
 @name YouTube Catppuccin
 @namespace github.com/catppuccin/youtube
 @homepageURL https://github.com/catppuccin/youtube
-@version 3.0.2
+@version 3.0.3
 @description Soothing pastel theme for YouTube
 @author isabelroses
 @license MIT

--- a/src/catppuccin.user.css
+++ b/src/catppuccin.user.css
@@ -654,6 +654,8 @@
       --ytd-author-comment-badge-background-color: @surface0 !important;
       --ytd-author-comment-badge-name-color: @text !important;
       --ytd-author-comment-badge-icon-color: @text !important;
+      padding-right: 6px;
+      padding-left: 8px;
     }
 
     /* badges e.g. popular */


### PR DESCRIPTION
I don't know what's causing this issue in the first place, but this fixes it.
The spacing around creators names in the comments is so little text pops out.
Here is my fix:
**BEFORE:**
![brave_Q2WhT0KeYw](https://github.com/catppuccin/youtube/assets/10319195/ca3dcb99-5ac0-47fb-806c-42e3c37241da)
**AFTER:**
![brave_sa5arCTvmV](https://github.com/catppuccin/youtube/assets/10319195/661e7206-af7c-4566-9ec7-34b0c1d4d0ed)

Here is YouTube's original stylesheet:
![image](https://github.com/catppuccin/youtube/assets/10319195/e83ed51e-38c8-4083-824f-ef5342f0940a)
